### PR TITLE
Avoid duplicate has-many

### DIFF
--- a/lib/db/cortex.php
+++ b/lib/db/cortex.php
@@ -1241,7 +1241,7 @@ class Cortex extends Cursor {
 						// update refs
 						elseif (is_array($val)) {
 							$mm->erase($filter);
-							foreach($val as $v) {
+							foreach(array_unique($val) as $v) {
 								if ($relConf['isSelf'] && $v==$id)
 									continue;
 								$mm->set($key,$v);


### PR DESCRIPTION
When adding new has-many relation with `$field[] = $new_id` with $new_id already existing as a relation, there was a duplicated line in the database. This avoids that