### PR TITLE
Fixes a bug in has( "something IN ?", array)

### DIFF
--- a/lib/db/cortex.php
+++ b/lib/db/cortex.php
@@ -736,7 +736,7 @@ class Cortex extends Cursor {
 							$has_filter=$this->mergeFilter([$has_filter,
 								[$this->rel($key)->getTable().'.'.$fromConf[1].'='.$this->getTable().'.'.$id]]);
 							$result = $this->_refSubQuery($key,$has_filter,$has_options);
-							$addToFilter = ['exists('.$result[0].')']+$result[1];
+							$addToFilter = array_merge(['exists('.$result[0].')'],$result[1]);
 						}
 						elseif ($result = $this->_hasRefsIn($key,$has_filter,$has_options,$ttl))
 							$addToFilter = array($id.' IN ?', $result);


### PR DESCRIPTION
'+' between arrays overwrites elements with the same index, even if numeral. 'array_merge' doesn't.