### PR TITLE
Fix return type value for `contains()`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1696,7 +1696,7 @@ NB: This is just a comparison - it actually does not update any of the collectio
 **check if the collection contains a record with the given key-val set**
 
 ```php
-array contains( mixed|Cortex $val [, string $key = '_id' ])
+bool contains( mixed|Cortex $val [, string $key = '_id' ])
 ```
 
 This method can come handy to check if a collections contains a given record, or has a record with a given value:


### PR DESCRIPTION
From what I see, the `contains()` function return `bool`, not `array`.

https://github.com/ikkez/f3-cortex/blob/dd930e611dfd491ceca215a319a97965ae37d263/lib/db/cortex.php#L3054-L3064