### PR TITLE
chore: fix load() first parameter type

### DIFF
--- a/lib/db/cortex.php
+++ b/lib/db/cortex.php
@@ -937,12 +937,12 @@ class Cortex extends Cursor {
 
 	/**
 	 * Retrieve first object that satisfies criteria
-	 * @param null  $filter
+	 * @param array|null  $filter
 	 * @param array $options
 	 * @param int   $ttl
 	 * @return bool
 	 */
-	public function load($filter = NULL, array $options = NULL, $ttl = 0) {
+	public function load(?array $filter = NULL, array $options = NULL, $ttl = 0) {
 		$this->reset(TRUE, FALSE);
 		$this->_ttl=$ttl?:$this->rel_ttl;
 		$res = $this->filteredFind($filter, $options, $ttl);


### PR DESCRIPTION
The doc say first parameter is an array, but the doctype says it's null

[doc](https://github.com/ikkez/f3-cortex#load)
```
bool load([ array $filter = NULL [, array $options = NULL [, int $ttl = 0 ]]])
```

what about changing the function declaration?