### PR TITLE
chore: fix load() first parameter type

### DIFF
--- a/lib/db/cortex.php
+++ b/lib/db/cortex.php
@@ -937,7 +937,7 @@ class Cortex extends Cursor {
 
 	/**
 	 * Retrieve first object that satisfies criteria
-	 * @param null  $filter
+	 * @param array|null  $filter
 	 * @param array $options
 	 * @param int   $ttl
 	 * @return bool


### PR DESCRIPTION
The doc say first parameter is an array, but the doctype says it's null

[doc](https://github.com/ikkez/f3-cortex#load)
```
bool load([ array $filter = NULL [, array $options = NULL [, int $ttl = 0 ]]])
```

what about changing the function declaration?

Link #119 